### PR TITLE
Update location URL for Zemismart Zigbee Blind

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -36,7 +36,7 @@
 		{
 			"name": "Zemismart Zigbee Blind",
 			"category": "Control",
-			"location": "https://raw.githubusercontent.com/amosyuen/hubitat-zemismart-zigbee/main/packageManifest.json",
+			"location": "https://raw.githubusercontent.com/HubitatCommunity/zemismart-zigbee-blind/refs/heads/main/packageManifest.json",
 			"description": "Zemismart zigbee blind device driver",
 			"tags": ["Window Coverings", "Zigbee"]
 		}


### PR DESCRIPTION
Zemismart's Zigbee blind driver for Hubitat remains quite popular within the HE community, with many new devices added in recent years. Recently, the code was added to the HubitatCommunity repository on GitHub.